### PR TITLE
Add summary graphs with date filtering

### DIFF
--- a/expensecrm/expenses/tests.py
+++ b/expensecrm/expenses/tests.py
@@ -23,3 +23,32 @@ class ExpenseViewsTest(TestCase):
         self.client.login(username='testuser', password='testpass')
         response = self.client.get(reverse('expense_list'))
         self.assertEqual(response.status_code, 200)
+
+    def test_expense_summary_date_filter(self):
+        user = User.objects.create_user(username='testuser', password='testpass')
+        self.client.login(username='testuser', password='testpass')
+
+        category1 = Category.objects.create(name='Food')
+        category2 = Category.objects.create(name='Travel')
+
+        Expense.objects.create(
+            date=date(2023, 1, 1),
+            category=category1,
+            description='Lunch',
+            amount=Decimal('10.00'),
+            payment_method='Cash',
+        )
+        Expense.objects.create(
+            date=date(2023, 2, 1),
+            category=category2,
+            description='Taxi',
+            amount=Decimal('20.00'),
+            payment_method='Cash',
+        )
+
+        response = self.client.get(
+            reverse('expense_summary'),
+            {'start_date': '2023-01-15', 'end_date': '2023-12-31'}
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.context['overall'], Decimal('20.00'))

--- a/expensecrm/templates/expenses/summary.html
+++ b/expensecrm/templates/expenses/summary.html
@@ -2,6 +2,21 @@
 {% block title %}Summary{% endblock %}
 {% block content %}
 <h1 class="mb-4">Expense Summary</h1>
+
+<form method="get" class="row g-3 mb-4">
+    <div class="col-auto">
+        <input type="date" name="start_date" value="{{ start_date }}" class="form-control" placeholder="Start date">
+    </div>
+    <div class="col-auto">
+        <input type="date" name="end_date" value="{{ end_date }}" class="form-control" placeholder="End date">
+    </div>
+    <div class="col-auto">
+        <button type="submit" class="btn btn-primary">Filter</button>
+    </div>
+</form>
+
+<canvas id="summaryChart" height="100" class="mb-4"></canvas>
+
 <table class="table table-bordered">
     <thead>
         <tr><th>Category</th><th class="text-end">Total</th></tr>
@@ -23,4 +38,30 @@
         </tr>
     </tfoot>
 </table>
+
+<script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+<script>
+const ctx = document.getElementById('summaryChart').getContext('2d');
+const labels = [{% for item in summary %}'{{ item.category__name }}'{% if not forloop.last %}, {% endif %}{% endfor %}];
+const data = [{% for item in summary %}{{ item.total }}{% if not forloop.last %}, {% endif %}{% endfor %}];
+new Chart(ctx, {
+    type: 'bar',
+    data: {
+        labels: labels,
+        datasets: [{
+            label: 'Total',
+            data: data,
+            backgroundColor: 'rgba(54, 162, 235, 0.5)',
+            borderColor: 'rgba(54, 162, 235, 1)',
+            borderWidth: 1
+        }]
+    },
+    options: {
+        scales: {
+            y: { beginAtZero: true }
+        },
+        plugins: { legend: { display: false } }
+    }
+});
+</script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- implement date filtering and chart data in `expense_summary` view
- add filter form and Chart.js graph on the summary template
- test summary filtering in the new view test

## Testing
- `pip install -r requirements.txt`
- `python expensecrm/manage.py test expenses`

------
https://chatgpt.com/codex/tasks/task_e_68627cde1b70832dbc4375e21b21560d