### PR TITLE
Make expenses list mobile friendly

### DIFF
--- a/expensecrm/static/css/styles.css
+++ b/expensecrm/static/css/styles.css
@@ -8,3 +8,29 @@ body {
     padding: 2rem;
     background-color: #ffffff;
 }
+
+/* Mobile friendly table for expenses */
+@media (max-width: 576px) {
+    .expenses-table thead {
+        display: none;
+    }
+    .expenses-table tr {
+        display: block;
+        margin-bottom: 1rem;
+        border-bottom: 1px solid #dee2e6;
+    }
+    .expenses-table td {
+        display: flex;
+        justify-content: space-between;
+        padding: 0.5rem;
+        position: relative;
+    }
+    .expenses-table td::before {
+        content: attr(data-label);
+        font-weight: 600;
+    }
+    .expenses-table td[data-label='Actions'] {
+        justify-content: flex-start;
+        gap: 0.5rem;
+    }
+}

--- a/expensecrm/templates/expenses/expense_list.html
+++ b/expensecrm/templates/expenses/expense_list.html
@@ -16,7 +16,7 @@
     </div>
 </form>
 <div class="table-responsive">
-    <table class="table table-striped">
+    <table class="table table-striped expenses-table">
         <thead>
             <tr>
                 <th>Date</th>
@@ -31,13 +31,13 @@
         <tbody>
             {% for expense in expenses %}
             <tr>
-                <td>{{ expense.date }}</td>
-                <td>{{ expense.category.name }}</td>
-                <td>{{ expense.description }}</td>
-                <td class="text-end">{{ expense.amount }}</td>
-                <td>{{ expense.payment_method }}</td>
-                <td>{{ expense.user.username }}</td>
-                <td>
+                <td data-label="Date">{{ expense.date }}</td>
+                <td data-label="Category">{{ expense.category.name }}</td>
+                <td data-label="Description">{{ expense.description }}</td>
+                <td data-label="Amount" class="text-end">{{ expense.amount }}</td>
+                <td data-label="Payment">{{ expense.payment_method }}</td>
+                <td data-label="User">{{ expense.user.username }}</td>
+                <td data-label="Actions">
                     <a href="{% url 'expense_edit' expense.pk %}" class="btn btn-sm btn-secondary">Edit</a>
                     <a href="{% url 'expense_delete' expense.pk %}" class="btn btn-sm btn-danger">Delete</a>
                 </td>


### PR DESCRIPTION
## Summary
- improve markup for the expenses table
- add responsive table CSS

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_686289d57960832db66605185de138e5