### PR TITLE
Implement bulk delete and chart type switch

### DIFF
--- a/expensecrm/expenses/urls.py
+++ b/expensecrm/expenses/urls.py
@@ -8,6 +8,7 @@ urlpatterns = [
     path('categories/add/', views.category_create, name='category_add'),
     path('<int:pk>/edit/', views.expense_update, name='expense_edit'),
     path('<int:pk>/delete/', views.expense_delete, name='expense_delete'),
+    path('bulk-delete/', views.expense_bulk_delete, name='expense_bulk_delete'),
     path('summary/', views.expense_summary, name='expense_summary'),
     path('register/', views.register, name='register'),
     path('login/', auth_views.LoginView.as_view(template_name='registration/login.html'), name='login'),

--- a/expensecrm/expenses/views.py
+++ b/expensecrm/expenses/views.py
@@ -84,6 +84,15 @@ def expense_delete(request, pk):
 
 
 @login_required
+def expense_bulk_delete(request):
+    if request.method == "POST":
+        ids = request.POST.getlist("selected_expenses")
+        if ids:
+            Expense.objects.filter(id__in=ids).delete()
+    return redirect("expense_list")
+
+
+@login_required
 def expense_summary(request):
     expenses = Expense.objects.select_related("category")
     start_date = request.GET.get("start_date")

--- a/expensecrm/templates/expenses/expense_list.html
+++ b/expensecrm/templates/expenses/expense_list.html
@@ -15,10 +15,17 @@
         <a href="{% url 'expense_add' %}" class="btn btn-primary">Add Expense</a>
     </div>
 </form>
-<div class="table-responsive">
+
+<form method="post" action="{% url 'expense_bulk_delete' %}" id="bulkDeleteForm">
+    {% csrf_token %}
+    <div class="mb-3">
+        <button type="submit" class="btn btn-danger" onclick="return confirm('Delete selected expenses?');">Delete Selected</button>
+    </div>
+    <div class="table-responsive">
     <table class="table table-striped expenses-table">
         <thead>
             <tr>
+                <th scope="col"><input type="checkbox" id="selectAll"></th>
                 <th>Date</th>
                 <th>Category</th>
                 <th>Description</th>
@@ -31,6 +38,7 @@
         <tbody>
             {% for expense in expenses %}
             <tr>
+                <td data-label="Select"><input type="checkbox" name="selected_expenses" value="{{ expense.pk }}" class="select-box"></td>
                 <td data-label="Date">{{ expense.date }}</td>
                 <td data-label="Category">{{ expense.category.name }}</td>
                 <td data-label="Description">{{ expense.description }}</td>
@@ -43,16 +51,23 @@
                 </td>
             </tr>
             {% empty %}
-            <tr><td colspan="7">No expenses found.</td></tr>
+            <tr><td colspan="8">No expenses found.</td></tr>
             {% endfor %}
         </tbody>
         <tfoot>
             <tr>
                 <td colspan="4"><strong>Total</strong></td>
                 <td class="text-end"><strong>{{ total }}</strong></td>
-                <td colspan="2"></td>
+                <td colspan="3"></td>
             </tr>
         </tfoot>
-    </table>
+</table>
 </div>
+</form>
+<script>
+document.getElementById('selectAll').addEventListener('change', function() {
+    const checked = this.checked;
+    document.querySelectorAll('.select-box').forEach(cb => cb.checked = checked);
+});
+</script>
 {% endblock %}

--- a/expensecrm/templates/expenses/summary.html
+++ b/expensecrm/templates/expenses/summary.html
@@ -19,7 +19,15 @@
     </div>
 </div>
 
-<canvas id="summaryChart" height="100" class="mb-4 w-100"></canvas>
+<div class="mb-3">
+    <label for="chartType" class="form-label">Chart Type</label>
+    <select id="chartType" class="form-select w-auto d-inline-block">
+        <option value="bar">Bar</option>
+        <option value="pie">Pie</option>
+        <option value="line">Line</option>
+    </select>
+</div>
+<canvas id="summaryChart" height="400" class="mb-4 w-100"></canvas>
 
 <div class="table-responsive">
     <table class="table table-bordered">
@@ -50,24 +58,30 @@
 const ctx = document.getElementById('summaryChart').getContext('2d');
 const labels = [{% for item in summary %}'{{ item.category__name }}'{% if not forloop.last %}, {% endif %}{% endfor %}];
 const data = [{% for item in summary %}{{ item.total }}{% if not forloop.last %}, {% endif %}{% endfor %}];
-new Chart(ctx, {
-    type: 'bar',
-    data: {
-        labels: labels,
-        datasets: [{
-            label: 'Total',
-            data: data,
-            backgroundColor: 'rgba(54, 162, 235, 0.5)',
-            borderColor: 'rgba(54, 162, 235, 1)',
-            borderWidth: 1
-        }]
-    },
-    options: {
-        scales: {
-            y: { beginAtZero: true }
+let chart;
+function renderChart(type) {
+    if (chart) chart.destroy();
+    chart = new Chart(ctx, {
+        type: type,
+        data: {
+            labels: labels,
+            datasets: [{
+                label: 'Total',
+                data: data,
+                backgroundColor: 'rgba(54, 162, 235, 0.5)',
+                borderColor: 'rgba(54, 162, 235, 1)',
+                borderWidth: 1
+            }]
         },
-        plugins: { legend: { display: false } }
-    }
+        options: {
+            scales: { y: { beginAtZero: true } },
+            plugins: { legend: { display: false } }
+        }
+    });
+}
+renderChart('bar');
+document.getElementById('chartType').addEventListener('change', function(e) {
+    renderChart(e.target.value);
 });
 </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- allow deleting multiple expenses via checkboxes
- add backend endpoint for bulk deletion
- let users choose chart type on summary page
- increase chart size and adjust script accordingly

## Testing
- `pip install -r requirements.txt`
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68628ad63a58832db4358df55394fb15