### PR TITLE
Fix mobile layout in expenses list

### DIFF
--- a/expensecrm/static/css/styles.css
+++ b/expensecrm/static/css/styles.css
@@ -10,7 +10,7 @@ body {
 }
 
 /* Mobile friendly table for expenses */
-@media (max-width: 576px) {
+@media (max-width: 768px) {
     .expenses-table thead {
         display: none;
     }
@@ -24,6 +24,7 @@ body {
         justify-content: space-between;
         padding: 0.5rem;
         position: relative;
+        word-break: break-word;
     }
     .expenses-table td::before {
         content: attr(data-label);
@@ -32,5 +33,11 @@ body {
     .expenses-table td[data-label='Actions'] {
         justify-content: flex-start;
         gap: 0.5rem;
+    }
+}
+
+@media (min-width: 576px) {
+    .w-sm-auto {
+        width: auto !important;
     }
 }

--- a/expensecrm/templates/expenses/expense_list.html
+++ b/expensecrm/templates/expenses/expense_list.html
@@ -3,7 +3,7 @@
 {% block content %}
 <h1 class="mb-4">Expenses</h1>
 <form method="get" class="row g-3 mb-3">
-    <div class="col-auto">
+    <div class="col-12 col-sm-auto">
         <select name="category" class="form-select" onchange="this.form.submit()">
             <option value="">All Categories</option>
             {% for c in categories %}
@@ -11,8 +11,8 @@
             {% endfor %}
         </select>
     </div>
-    <div class="col-auto">
-        <a href="{% url 'expense_add' %}" class="btn btn-primary">Add Expense</a>
+    <div class="col-12 col-sm-auto">
+        <a href="{% url 'expense_add' %}" class="btn btn-primary d-block d-sm-inline-block w-100 w-sm-auto">Add Expense</a>
     </div>
 </form>
 


### PR DESCRIPTION
## Summary
- tweak expenses list table styles for better mobile view
- adjust filter form layout for small screens

## Testing
- `pip install -r requirements.txt`
- `python manage.py test expenses`

------
https://chatgpt.com/codex/tasks/task_e_68628bfe313c832d85a3c7e5a5d64d07