### PR TITLE
Fix page title default

### DIFF
--- a/expensecrm/templates/expenses/expense_list.html
+++ b/expensecrm/templates/expenses/expense_list.html
@@ -1,5 +1,4 @@
 {% extends 'base.html' %}
-{% block title %}Expenses{% endblock %}
 {% block content %}
 <h1 class="mb-4">Expenses</h1>
 <form method="get" class="row g-3 mb-3">


### PR DESCRIPTION
## Summary
- remove title override so page title defaults to `ALAA MOHRA CRM`

## Testing
- `python expensecrm/manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68628f529e3c832d93720f63ea86ddbe