### PR TITLE
Improve mobile expense selection and styling

### DIFF
--- a/expensecrm/expenses/forms.py
+++ b/expensecrm/expenses/forms.py
@@ -1,5 +1,5 @@
 from django import forms
-from django.contrib.auth.forms import UserCreationForm
+from django.contrib.auth.forms import UserCreationForm, AuthenticationForm
 from django.contrib.auth.models import User
 from .models import Expense, Category
 
@@ -35,3 +35,10 @@ class RegisterForm(UserCreationForm):
             "password1": forms.PasswordInput(attrs={"class": "form-control"}),
             "password2": forms.PasswordInput(attrs={"class": "form-control"}),
         }
+
+
+class LoginForm(AuthenticationForm):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        for field in self.fields.values():
+            field.widget.attrs.update({"class": "form-control"})

--- a/expensecrm/expenses/urls.py
+++ b/expensecrm/expenses/urls.py
@@ -1,6 +1,7 @@
 from django.urls import path
 from django.contrib.auth import views as auth_views
 from . import views
+from .forms import LoginForm
 
 urlpatterns = [
     path('', views.expense_list, name='expense_list'),
@@ -11,6 +12,9 @@ urlpatterns = [
     path('bulk-delete/', views.expense_bulk_delete, name='expense_bulk_delete'),
     path('summary/', views.expense_summary, name='expense_summary'),
     path('register/', views.register, name='register'),
-    path('login/', auth_views.LoginView.as_view(template_name='registration/login.html'), name='login'),
+    path('login/', auth_views.LoginView.as_view(
+        template_name='registration/login.html',
+        authentication_form=LoginForm
+    ), name='login'),
     path('logout/', auth_views.LogoutView.as_view(), name='logout'),
 ]

--- a/expensecrm/static/css/styles.css
+++ b/expensecrm/static/css/styles.css
@@ -1,6 +1,6 @@
 body {
     padding-top: 20px;
-    background: linear-gradient(135deg, #74ebd5, #ACB6E5);
+    background: linear-gradient(135deg, #e0eafc, #cfdef3);
     min-height: 100vh;
 }
 
@@ -52,4 +52,14 @@ body {
     .w-sm-auto {
         width: auto !important;
     }
+}
+
+.expense-card-summary {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+.expense-card-summary span {
+    word-break: break-word;
+    overflow-wrap: anywhere;
 }

--- a/expensecrm/templates/expenses/expense_list.html
+++ b/expensecrm/templates/expenses/expense_list.html
@@ -62,13 +62,13 @@
         </tfoot>
 </table>
     </div>
-</form>
 
-<div class="d-block d-md-none">
+    <div class="d-block d-md-none">
     {% for expense in expenses %}
     <details class="expense-card mb-3">
-        <summary class="expense-card-summary d-flex justify-content-between align-items-center">
-            <span>{{ expense.date }} - {{ expense.category.name }}</span>
+        <summary class="expense-card-summary d-flex align-items-center">
+            <input type="checkbox" name="selected_expenses" value="{{ expense.pk }}" class="form-check-input select-box me-2" />
+            <span class="flex-grow-1">{{ expense.date }} - {{ expense.category.name }}</span>
             <span>{{ expense.amount }}</span>
         </summary>
         <div class="card card-body">
@@ -86,6 +86,7 @@
     {% endfor %}
     <div class="mt-2"><strong>Total:</strong> {{ total }}</div>
 </div>
+</form>
 <script>
 document.getElementById('selectAll').addEventListener('change', function() {
     const checked = this.checked;


### PR DESCRIPTION
## Summary
- add custom `LoginForm` and connect it in URL configuration
- allow selecting expense cards for bulk deletion on mobile
- update gradient styling and add mobile card styles

## Testing
- `pip install -r requirements.txt`
- `python expensecrm/manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_6862923f367c832db1fe05e434e1a03c