### PR TITLE
Use environment variable for API URLs

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,1 @@
+VITE_API_URL=https://api.example.com

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -60,6 +60,12 @@ This project is built with:
 - shadcn-ui
 - Tailwind CSS
 
+## Configuring the API URL
+
+API requests use the `VITE_API_URL` environment variable. Copy `.env.example` to
+`.env` and set this value to your backend's base URL before running the dev
+server or building the project.
+
 ## How can I deploy this project?
 
 Simply open [Lovable](https://lovable.dev/projects/b3d448b1-4abf-4bd4-a26f-d424d27a7027) and click on Share -> Publish.

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -17,6 +17,9 @@ interface AuthContextType {
 
 const AuthContext = createContext<AuthContextType | undefined>(undefined);
 
+// Base URL for API requests, configurable via Vite environment variable
+const API_BASE = import.meta.env.VITE_API_URL ?? '';
+
 export const useAuth = () => {
   const context = useContext(AuthContext);
   if (context === undefined) {
@@ -48,7 +51,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
     try {
       setIsLoading(true);
 
-      const response = await fetch('/api/login/', {
+      const response = await fetch(`${API_BASE}/api/login/`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -81,7 +84,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
         throw new Error('Passwords do not match');
       }
 
-      const response = await fetch('/api/signup/', {
+      const response = await fetch(`${API_BASE}/api/signup/`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',


### PR DESCRIPTION
## Summary
- use `VITE_API_URL` when calling login/signup APIs
- add `.env.example`
- document API base URL variable in frontend README

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js' and lint errors)*
- `npm run build`
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_686d938d053c832da36615dd6a339cb7